### PR TITLE
update/changes when QComboBox items are changed

### DIFF
--- a/window.py
+++ b/window.py
@@ -241,8 +241,8 @@ class ConfigLayout(QBoxLayout):
 
         self.widget_updates.append(update)
 
-        combobox.currentIndexChanged.connect(
-            lambda idx: self.conf.set(key, values[idx])
+        combobox.currentTextChanged.connect(
+            lambda text: self.conf.set(key, text)
         )
 
         if description is not None:


### PR DESCRIPTION
A small change.
The background is that I am implementing two dropdowns.
The second dropdown items are dependent on the chosen item in the first dropdown, i.e., the second dropdown items will be updated if the chosen item in the first dropdown is changed.

I also changed the index to text, but possibly it may lead to some bugs.