### PR TITLE
feat: Add `shortcut_input` to `ConfigLayout`

### DIFF
--- a/window.py
+++ b/window.py
@@ -241,7 +241,9 @@ class ConfigLayout(QBoxLayout):
 
         self.widget_updates.append(update)
 
-        combobox.currentTextChanged.connect(lambda text: self.conf.set(key, text))
+        combobox.currentTextChanged.connect(
+            lambda text: self.conf.set(key, text)
+        )
 
         if description is not None:
             row = self.hlayout()

--- a/window.py
+++ b/window.py
@@ -476,8 +476,6 @@ class ConfigLayout(QBoxLayout):
             lambda s: self.conf.set(key, edit.keySequence().toString())
         )
 
-        self.addWidget(edit)
-
         def on_shortcut_clear_btn_click() -> None:
             edit.clear()
 

--- a/window.py
+++ b/window.py
@@ -241,9 +241,7 @@ class ConfigLayout(QBoxLayout):
 
         self.widget_updates.append(update)
 
-        combobox.currentTextChanged.connect(
-            lambda text: self.conf.set(key, text)
-        )
+        combobox.currentTextChanged.connect(lambda text: self.conf.set(key, text))
 
         if description is not None:
             row = self.hlayout()
@@ -455,6 +453,46 @@ class ConfigLayout(QBoxLayout):
         button.clicked.connect(get_path)
 
         return (line_edit, button)
+
+    def shortcut_input(
+        self, key: str, description: Optional[str] = None, tooltip: Optional[str] = None
+    ) -> Tuple[QKeySequenceEdit, QPushButton]:
+        edit = QKeySequenceEdit()
+
+        if description is not None:
+            row = self.hlayout()
+            row.text(description, tooltip=tooltip)
+
+        def update() -> None:
+            val = self.conf.get(key)
+            if not isinstance(val, str):
+                raise InvalidConfigValueError(key, "str", val)
+            val = val.replace(" ", "")
+            edit.setKeySequence(val)
+
+        self.widget_updates.append(update)
+
+        edit.keySequenceChanged.connect(  # type: ignore
+            lambda s: self.conf.set(key, edit.keySequence().toString())
+        )
+
+        self.addWidget(edit)
+
+        def on_shortcut_clear_btn_click() -> None:
+            edit.clear()
+
+        shortcut_clear_btn = QPushButton("Clear")
+        shortcut_clear_btn.setSizePolicy(
+            QSizePolicy.Policy.Fixed, QSizePolicy.Policy.Fixed
+        )
+        shortcut_clear_btn.clicked.connect(on_shortcut_clear_btn_click)  # type: ignore
+
+        layout = QHBoxLayout()
+        layout.addWidget(edit)
+        layout.addWidget(shortcut_clear_btn)
+
+        self.addLayout(layout)
+        return edit, shortcut_clear_btn
 
     # Layout widgets
 


### PR DESCRIPTION
Many add-ons have configurable hotkeys for certain actions. This PR adds a `shortcut_input` to `ankiaddonconfig.window.ConfigLayout`.

## Screenshot
<img src="https://github.com/BlueGreenMagick/ankiaddonconfig/assets/31575114/f1da6926-67f5-4aa4-a22a-abc40f92c8f1" width="400" />