### PR TITLE
fix: dropdown - set value instead of label

### DIFF
--- a/window.py
+++ b/window.py
@@ -241,8 +241,8 @@ class ConfigLayout(QBoxLayout):
 
         self.widget_updates.append(update)
 
-        combobox.currentTextChanged.connect(
-            lambda text: self.conf.set(key, text)
+        combobox.currentIndexChanged.connect(
+            lambda idx: self.conf.set(key, values[idx])
         )
 
         if description is not None:


### PR DESCRIPTION
This PR fixes a bug in `ConfigLayout.dropdown`. Previously the code was setting the value in the config to the label of the selected option. With the fix it uses the value of the option instead.